### PR TITLE
Support hasContext with types improvement

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,15 +1,27 @@
 import {
   getContext as svelteGetContext,
   setContext as svelteSetContext,
+  hasContext as svelteHasContext,
 } from "svelte"
+
+declare const isChecked: unique symbol;
 
 /**
  * Provided as key to getContext and setContext in order to enable strict typing
  */
 export interface InjectionKey<T = unknown> { }
 
-type getContext = <T>(key: InjectionKey<T>) => undefined | T
+export interface CheckedInjectionKey<T> extends InjectionKey<T> {
+  [isChecked]?: never;
+}
+
+type getContext = {
+  <T>(key: CheckedInjectionKey<T>): T
+  <T>(key: InjectionKey<T>): undefined | T
+}
 type setContext = <T>(key: InjectionKey<T>, context: T) => void
+type hasContext = <T>(key: InjectionKey<T>) => key is CheckedInjectionKey<T>
 
 export const getContext = svelteGetContext as getContext
 export const setContext = svelteSetContext as setContext
+export const hasContext = svelteHasContext as hasContext


### PR DESCRIPTION
Hi,

Svelte has api for check that context with some key exists: [hasContext](https://svelte.dev/docs#hasContext)

In this change I reexport it as type guard that changes key type from `InjectionKey` to `CheckedInjectionKey`.
Also I overload `getContext` with support `CheckedInjectionKey` for return non undefined context value if `hasContext` was checked.